### PR TITLE
allow RESTful creation of items to omit QTI XML tags

### DIFF
--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -766,9 +766,17 @@ files, via the `repository` endpoint for `asset`s. This is demonstrated in
 
 Full RESTful documentation is probably best done by example, in viewing the tests.
 You can see the RESTful tests in `tests.test_assessment.py`, specifically the
-`QTIEndpointTests` class. You can also refer to `ItemDetails` `PUT` to see the various fields.
+`QTIEndpointTests` class. Note that it is preferred, when creating items via REST,
+to upload text without the QTI-specific wrappers like `<itemBody>` and `<simpleChoice>`.
+That way the questions can easily be reformatted to other standards.
+You can also refer to `ItemDetails` `PUT` above for more details.
 
 Useful tests to reference are:
+  - test_item_body_and_inline_choice_tags_provided_inline_choice
+  - test_item_body_and_simple_choice_tags_provided_multiple_choice
+  - test_item_body_and_simple_choice_tags_provided_order_interaction
+  - test_item_body_provided_audio_upload
+  - test_item_body_provided_numeric_response
   - test_can_create_audio_record_tool_question_via_rest
   - test_can_create_fill_in_the_blank_question_via_rest
   - test_can_create_generic_file_upload_question_via_rest

--- a/tests/test_assessment.py
+++ b/tests/test_assessment.py
@@ -9512,6 +9512,174 @@ class QTIEndpointTests(BaseAssessmentTestCase):
                 expected_choices[choice_id]
             )
 
+    def test_item_body_and_simple_choice_tags_provided_multiple_choice(self):
+        media_files = [self._green_dot_image,
+                       self._h1i_image]
+
+        assets = {}
+        for media_file in media_files:
+            label = self._label(self._filename(media_file))
+            assets[label] = self.upload_media_file(media_file)
+
+        url = '{0}/items'.format(self.url)
+
+        payload = {
+            "genusTypeId": str(QTI_ITEM_CHOICE_INTERACTION_GENUS),
+            "name": "Question 1",
+            "description": "For testing",
+            "question": {
+                "questionString": """<p>Which of the following is a circle?</p>""",
+                "choices": [{
+                    "id": "idc561552b-ed48-46c3-b20d-873150dfd4a2",
+                    "text": """<p>
+  <img src="AssetContent:green_dot_png" alt="image 1" width="20" height="20" />
+</p>"""
+                }, {
+                    "id": "ida86a26e0-a563-4e48-801a-ba9d171c24f7",
+                    "text": """<p>|__|</p>"""
+                }, {
+                    "id": "id32b596f4-d970-4d1e-a667-3ca762c002c5",
+                    "text": """<p>
+  <img src="AssetContent:h1i_png" alt="image 2" width="26" height="24" />
+</p>"""
+                }],
+                "genusTypeId": str(QTI_QUESTION_CHOICE_INTERACTION_GENUS),
+                "shuffle": True,
+                "fileIds": {}
+            },
+            "answers": [{
+                "genusTypeId": str(RIGHT_ANSWER_GENUS),
+                "choiceIds": ["idc561552b-ed48-46c3-b20d-873150dfd4a2"],
+                "feedback": """<modalFeedback  identifier="Feedback933928139" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+  <p id="docs-internal-guid-46f83555-04cc-a70f-2574-1b5c79fe206e" dir="ltr">You are correct! A square has the properties of both a rectangle, and a rhombus. Hence, it can also occupy the shaded region.</p>
+</modalFeedback>"""
+            }, {
+                "genusTypeId": str(WRONG_ANSWER_GENUS),
+                "feedback": """<modalFeedback  identifier="Feedback506508014" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+  <p>
+    <strong>
+      <span id="docs-internal-guid-46f83555-04cc-d077-5f2e-58f80bf813e2">Please try again!</span>
+      <br />
+    </strong>
+  </p>
+</modalFeedback>"""
+            }]
+        }
+
+        for label, asset in assets.iteritems():
+            payload['question']['fileIds'][label] = {}
+            payload['question']['fileIds'][label]['assetId'] = asset['id']
+            payload['question']['fileIds'][label]['assetContentId'] = asset['assetContents'][0]['id']
+            payload['question']['fileIds'][label]['assetContentTypeId'] = asset['assetContents'][0]['genusTypeId']
+
+        req = self.app.post(url,
+                            params=json.dumps(payload),
+                            headers={'content-type': 'application/json'})
+        self.ok(req)
+        item = self.json(req)
+
+        self.assertEqual(
+            item['genusTypeId'],
+            str(QTI_ITEM_CHOICE_INTERACTION_GENUS)
+        )
+
+        self.assertEqual(
+            item['question']['genusTypeId'],
+            str(QTI_QUESTION_CHOICE_INTERACTION_GENUS)
+        )
+
+        self.assertEqual(
+            item['answers'][0]['genusTypeId'],
+            str(RIGHT_ANSWER_GENUS)
+        )
+
+        self.assertNotEqual(
+            item['id'],
+            str(self._item.ident)
+        )
+
+        # now verify the QTI XML matches the JSON format
+        url = '{0}/{1}/qti'.format(url, unquote(item['id']))
+        req = self.app.get(url)
+        self.ok(req)
+        qti_xml = BeautifulSoup(req.body, 'lxml-xml').assessmentItem
+        item_body = qti_xml.itemBody
+
+        choice_interaction = item_body.choiceInteraction.extract()
+
+        image_1_asset_label = 'green_dot_png'
+        image_2_asset_label = 'h1i_png'
+        image_1_asset_id = item['question']['fileIds'][image_1_asset_label]['assetId']
+        image_1_asset_content_id = item['question']['fileIds'][image_1_asset_label]['assetContentId']
+
+        image_2_asset_id = item['question']['fileIds'][image_2_asset_label]['assetId']
+        image_2_asset_content_id = item['question']['fileIds'][image_2_asset_label]['assetContentId']
+
+        expected_string = """<itemBody>
+<p>
+   Which of the following is a circle?
+  </p>
+
+</itemBody>"""
+
+        self.assertEqual(
+            str(item_body),
+            expected_string
+        )
+
+        self.assertEqual(
+            str(item_body),
+            expected_string
+        )
+
+        self.assertEqual(
+            len(choice_interaction.find_all('simpleChoice')),
+            3
+        )
+        self.assertEqual(
+            choice_interaction['maxChoices'],
+            "1"
+        )
+        self.assertEqual(
+            choice_interaction['responseIdentifier'],
+            'RESPONSE_1'
+        )
+        self.assertEqual(
+            choice_interaction['shuffle'],
+            'true'
+        )
+
+        repository_id = str(self._bank.ident).replace('assessment.Bank', 'repository.Repository')
+
+        expected_choices = {
+            "idc561552b-ed48-46c3-b20d-873150dfd4a2": """<simpleChoice identifier="idc561552b-ed48-46c3-b20d-873150dfd4a2">
+<p>
+<img alt="image 1" height="20" src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" width="20"/>
+</p>
+</simpleChoice>""".format(repository_id,
+                          image_1_asset_id,
+                          image_1_asset_content_id),
+            "ida86a26e0-a563-4e48-801a-ba9d171c24f7": """<simpleChoice identifier="ida86a26e0-a563-4e48-801a-ba9d171c24f7">
+<p>
+     |__|
+    </p>
+</simpleChoice>""",
+            "id32b596f4-d970-4d1e-a667-3ca762c002c5": """<simpleChoice identifier="id32b596f4-d970-4d1e-a667-3ca762c002c5">
+<p>
+<img alt="image 2" height="24" src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" width="26"/>
+</p>
+</simpleChoice>""".format(repository_id,
+                          image_2_asset_id,
+                          image_2_asset_content_id)
+        }
+
+        for choice in choice_interaction.find_all('simpleChoice'):
+            choice_id = choice['identifier']
+            self.assertEqual(
+                str(choice),
+                expected_choices[choice_id]
+            )
+
     def test_can_create_multi_choice_multi_answer_question_via_rest(self):
         media_files = [self._square_image,
                        self._diamond_image,
@@ -10136,6 +10304,118 @@ class QTIEndpointTests(BaseAssessmentTestCase):
         self.assertEqual(
             item['question']['timeValue'],
             {'hours': '00', 'minutes': '01', 'seconds': '40'}
+        )
+
+        item_qti_url = '{0}/{1}/qti'.format(url, item['id'])
+        req = self.app.get(item_qti_url)
+        self.ok(req)
+        qti_xml = BeautifulSoup(req.body, 'lxml-xml').assessmentItem
+        item_body = qti_xml.itemBody
+
+        audio_asset_label = 'audioTestFile__mp3'
+        audio_asset_id = item['question']['fileIds'][audio_asset_label]['assetId']
+        audio_asset_content_id = item['question']['fileIds'][audio_asset_label]['assetContentId']
+
+        expected_string = """<itemBody>
+<p>
+<audio autoplay="autoplay" controls="controls" style="width: 125px">
+<source src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" type="audio/mpeg"/>
+</audio>
+</p>
+<p>
+<strong>
+    Introducting a new student
+   </strong>
+</p>
+<p>
+   It's the first day of school after the summer vacations. A new student has joined the class
+  </p>
+<p>
+   Student 1 talks to the new student to make him/her feel comfortable.
+  </p>
+<p>
+   Student 2 talks about herself or himself and asks a few questions about the new school
+  </p>
+<uploadInteraction responseIdentifier="RESPONSE_1"/>
+</itemBody>""".format(str(self._bank.ident).replace('assessment.Bank', 'repository.Repository'),
+                      audio_asset_id,
+                      audio_asset_content_id)
+
+        self.assertEqual(
+            str(item_body),
+            expected_string
+        )
+
+    def test_item_body_provided_audio_upload(self):
+        media_files = [self._audio_test_file]
+
+        assets = {}
+        for media_file in media_files:
+            label = self._label(self._filename(media_file))
+            assets[label] = self.upload_media_file(media_file)
+
+        url = '{0}/items'.format(self.url)
+        payload = {
+            "genusTypeId": str(QTI_ITEM_UPLOAD_INTERACTION_AUDIO_GENUS),
+            "name": "Question 1",
+            "description": "For testing",
+            "question": {
+                "questionString": """<p>
+<audio autoplay="autoplay" controls="controls" style="width: 125px">
+<source src="AssetContent:audioTestFile__mp3" type="audio/mpeg"/>
+</audio></p>
+<p>
+  <strong>Introducting a new student</strong>
+</p>
+<p>It's the first day of school after the summer vacations. A new student has joined the class</p>
+<p>Student 1 talks to the new student to make him/her feel comfortable.</p>
+<p>Student 2 talks about herself or himself and asks a few questions about the new school</p>""",
+                "genusTypeId": str(QTI_QUESTION_UPLOAD_INTERACTION_AUDIO_GENUS),
+                "fileIds": {}
+            },
+            "answers": [{
+                "genusTypeId": str(RIGHT_ANSWER_GENUS),
+                "feedback": """<modalFeedback  identifier="Feedback" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+<p></p>
+</modalFeedback>"""
+            }]
+        }
+
+        for label, asset in assets.iteritems():
+            payload['question']['fileIds'][label] = {}
+            payload['question']['fileIds'][label]['assetId'] = asset['id']
+            payload['question']['fileIds'][label]['assetContentId'] = asset['assetContents'][0]['id']
+            payload['question']['fileIds'][label]['assetContentTypeId'] = asset['assetContents'][0]['genusTypeId']
+
+        req = self.app.post(url,
+                            params=json.dumps(payload),
+                            headers={'content-type': 'application/json'})
+        self.ok(req)
+        item = self.json(req)
+
+        self.assertEqual(
+            item['genusTypeId'],
+            str(QTI_ITEM_UPLOAD_INTERACTION_AUDIO_GENUS)
+        )
+
+        self.assertEqual(
+            item['question']['genusTypeId'],
+            str(QTI_QUESTION_UPLOAD_INTERACTION_AUDIO_GENUS)
+        )
+
+        self.assertEqual(
+            item['answers'][0]['genusTypeId'],
+            str(RIGHT_ANSWER_GENUS)
+        )
+
+        self.assertEqual(
+            item['answers'][0]['feedbacks'][0]['text'],
+            '<modalFeedback  identifier="Feedback" outcomeIdentifier="FEEDBACKMODAL" showHide="show">\n<p></p>\n</modalFeedback>'
+        )
+
+        self.assertNotEqual(
+            item['id'],
+            str(self._item.ident)
         )
 
         item_qti_url = '{0}/{1}/qti'.format(url, item['id'])
@@ -11132,6 +11412,250 @@ class QTIEndpointTests(BaseAssessmentTestCase):
                 expected_choices[choice_id]
             )
 
+    def test_item_body_and_inline_choice_tags_provided_inline_choice(self):
+        url = '{0}/items'.format(self.url)
+
+        payload = {
+            "genusTypeId": str(QTI_ITEM_INLINE_CHOICE_INTERACTION_GENUS),
+            "name": "Question 1",
+            "description": "For testing",
+            "question": {
+                "questionString": """<p>
+<span data-sheets-userformat=\"{\" data-sheets-value=\"{\">
+<p>
+<p class="other">
+      Putting things away
+     </p>
+<p class="preposition">
+      in
+     </p>
+<p class="other">
+      the
+     </p>
+<p class="adjective">
+      proper
+     </p>
+<p class="noun">
+      place
+     </p>
+<p class="verb">
+      makes
+     </p>
+<p class="noun">
+      it
+     </p>
+</p>
+
+<inlineChoiceInteraction responseIdentifier="RESPONSE_1" shuffle="false" />
+
+<p>
+<p class="other">
+      to
+     </p>
+<p class="verb">
+      find
+     </p>
+<p class="noun">
+      them
+     </p>
+<p class="adverb">
+      later
+     </p>
+     .
+    </p>
+</span>
+</p>""",
+                "inlineRegions": {
+                    "RESPONSE_1": {
+                        "choices": [{
+                            "id": "[_1_1",
+                            "text": """<p class="adjective">easy</p>"""
+                        }, {
+                            "id": "[_1_1_1",
+                            "text": """<p class="adjective">neat</p>"""
+                        }, {
+                            "id": "[_2_1_1",
+                            "text": """<p class="adjective">fast</p>"""
+                        }, {
+                            "id": "[_3_1_1",
+                            "text": """<p class="adjective">good</p>"""
+                        }],
+                    }
+                },
+                "genusTypeId": str(QTI_QUESTION_INLINE_CHOICE_INTERACTION_GENUS),
+                "shuffle": True
+            },
+            "answers": [{
+                "genusTypeId": str(RIGHT_ANSWER_GENUS),
+                "choiceIds": ['[_1_1'],
+                "region": "RESPONSE_1",
+                "feedback": """  <modalFeedback  identifier="Feedback372632509" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+<p>You are right! Please try the next question.</p>
+</modalFeedback>"""
+            }, {
+                "genusTypeId": str(WRONG_ANSWER_GENUS),
+                "choiceIds": [None],
+                "region": "RESPONSE_1",
+                "feedback": """  <modalFeedback  identifier="Feedback2014412711" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+<p>Please try again.</p>
+</modalFeedback>"""
+            }]
+        }
+
+        req = self.app.post(url,
+                            params=json.dumps(payload),
+                            headers={'content-type': 'application/json'})
+        self.ok(req)
+        item = self.json(req)
+
+        self.assertEqual(
+            item['genusTypeId'],
+            str(QTI_ITEM_INLINE_CHOICE_INTERACTION_GENUS)
+        )
+
+        self.assertEqual(
+            item['question']['genusTypeId'],
+            str(QTI_QUESTION_INLINE_CHOICE_INTERACTION_GENUS)
+        )
+
+        self.assertIn('RESPONSE_1', item['question']['choices'])
+
+        response_1_choice_ids = [c['id'] for c in item['question']['choices']['RESPONSE_1']]
+
+        self.assertIn('[_1_1', response_1_choice_ids)
+
+        self.assertEqual(
+            len(item['answers']),
+            2
+        )
+
+        self.assertEqual(
+            item['answers'][0]['genusTypeId'],
+            str(RIGHT_ANSWER_GENUS)
+        )
+        self.assertIn('RESPONSE_1', item['answers'][0]['inlineRegions'])
+
+        self.assertEqual(
+            item['answers'][0]['inlineRegions']['RESPONSE_1']['choiceIds'],
+            ['[_1_1']
+        )
+        self.assertIn('You are right! Please try the next question.', item['answers'][0]['feedbacks'][0]['text'])
+
+        self.assertEqual(
+            item['answers'][1]['genusTypeId'],
+            str(WRONG_ANSWER_GENUS)
+        )
+
+        self.assertIn('Please try again.', item['answers'][1]['feedbacks'][0]['text'])
+
+        self.assertNotEqual(
+            item['id'],
+            str(self._item.ident)
+        )
+
+        # now verify the QTI XML matches the JSON format
+        url = '{0}/{1}/qti'.format(url, unquote(item['id']))
+        req = self.app.get(url)
+        self.ok(req)
+        qti_xml = BeautifulSoup(req.body, 'lxml-xml').assessmentItem
+        item_body = qti_xml.itemBody
+
+        inline_choice_interaction = item_body.inlineChoiceInteraction.extract()
+
+        expected_string = """<itemBody>
+<p>
+<span data-sheets-userformat=\"{\" data-sheets-value=\"{\">
+<p>
+<p class="other">
+      Putting things away
+     </p>
+<p class="preposition">
+      in
+     </p>
+<p class="other">
+      the
+     </p>
+<p class="adjective">
+      proper
+     </p>
+<p class="noun">
+      place
+     </p>
+<p class="verb">
+      makes
+     </p>
+<p class="noun">
+      it
+     </p>
+</p>
+
+<p>
+<p class="other">
+      to
+     </p>
+<p class="verb">
+      find
+     </p>
+<p class="noun">
+      them
+     </p>
+<p class="adverb">
+      later
+     </p>
+     .
+    </p>
+</span>
+</p>
+</itemBody>"""
+
+        self.assertEqual(
+            str(item_body),
+            expected_string
+        )
+
+        self.assertEqual(
+            len(inline_choice_interaction.find_all('inlineChoice')),
+            4
+        )
+        self.assertEqual(
+            inline_choice_interaction['responseIdentifier'],
+            'RESPONSE_1'
+        )
+        self.assertEqual(
+            inline_choice_interaction['shuffle'],
+            'false'
+        )
+
+        expected_choices = {
+            "[_1_1": """<inlineChoice identifier="[_1_1">
+<p class="adjective">
+      easy
+     </p>
+</inlineChoice>""",
+            "[_1_1_1": """<inlineChoice identifier="[_1_1_1">
+<p class="adjective">
+      neat
+     </p>
+</inlineChoice>""",
+            "[_2_1_1": """<inlineChoice identifier="[_2_1_1">
+<p class="adjective">
+      fast
+     </p>
+</inlineChoice>""",
+            "[_3_1_1": """<inlineChoice identifier="[_3_1_1">
+<p class="adjective">
+      good
+     </p>
+</inlineChoice>"""
+        }
+
+        for choice in inline_choice_interaction.find_all('simpleChoice'):
+            choice_id = choice['identifier']
+            self.assertEqual(
+                str(choice),
+                expected_choices[choice_id]
+            )
+
     def test_can_create_short_answer_question_via_rest(self):
         media_files = [self._shapes_image]
 
@@ -11470,6 +11994,212 @@ class QTIEndpointTests(BaseAssessmentTestCase):
                 expected_choices[choice_id]
             )
 
+    def test_item_body_and_simple_choice_tags_provided_order_interaction(self):
+        media_files = [self._audio_test_file,
+                       self._picture1,
+                       self._picture2,
+                       self._picture3,
+                       self._picture4]
+
+        assets = {}
+        for media_file in media_files:
+            label = self._label(self._filename(media_file))
+            assets[label] = self.upload_media_file(media_file)
+
+        url = '{0}/items'.format(self.url)
+
+        payload = {
+            "genusTypeId": str(QTI_ITEM_ORDER_INTERACTION_OBJECT_MANIPULATION_GENUS),
+            "name": "Question 1",
+            "description": "For testing",
+            "question": {
+                "questionString": """<p>
+   Listen to each audio clip and put the pictures of the story in order.
+  </p>
+<p>
+<audio autoplay="autoplay" controls="controls" style="width: 125px">
+<source src="AssetContent:audioTestFile__mp3" type="audio/mpeg"/>
+</audio>
+</p>""",
+                "choices": [{
+                    "id": "idb4f6cd03-cf58-4391-9ca2-44b7bded3d4b",
+                    "text": """<p>
+  <img src="AssetContent:Picture1_png" alt="Picture 1" width="100" height="100" />
+</p>"""
+                }, {
+                    "id": "id127df214-2a19-44da-894a-853948313dae",
+                    "text": """<p>
+  <img src="AssetContent:Picture2_png" alt="Picture 2" width="100" height="100" />
+</p>"""
+                }, {
+                    "id": "iddcbf40ab-782e-4d4f-9020-6b8414699a72",
+                    "text": """<p>
+  <img src="AssetContent:Picture3_png" alt="Picture 3" width="100" height="100" />
+</p>"""
+                }, {
+                    "id": "ide576c9cc-d20e-4ba3-8881-716100b796a0",
+                    "text": """<p>
+  <img src="AssetContent:Picture4_png" alt="Picture 4" width="100" height="100" />
+</p>"""
+                }],
+                "genusTypeId": str(QTI_QUESTION_ORDER_INTERACTION_OBJECT_MANIPULATION_GENUS),
+                "shuffle": True,
+                "fileIds": {}
+            },
+            "answers": [{
+                "genusTypeId": str(RIGHT_ANSWER_GENUS),
+                "choiceIds": ['id127df214-2a19-44da-894a-853948313dae',
+                              'iddcbf40ab-782e-4d4f-9020-6b8414699a72',
+                              'idb4f6cd03-cf58-4391-9ca2-44b7bded3d4b',
+                              'ide576c9cc-d20e-4ba3-8881-716100b796a0'],
+                "feedback": """<modalFeedback  identifier="Feedback933928139" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+  <p id="docs-internal-guid-46f83555-04cc-a70f-2574-1b5c79fe206e" dir="ltr">You are correct! A square has the properties of both a rectangle, and a rhombus. Hence, it can also occupy the shaded region.</p>
+</modalFeedback>"""
+            }]
+        }
+
+        for label, asset in assets.iteritems():
+            payload['question']['fileIds'][label] = {}
+            payload['question']['fileIds'][label]['assetId'] = asset['id']
+            payload['question']['fileIds'][label]['assetContentId'] = asset['assetContents'][0]['id']
+            payload['question']['fileIds'][label]['assetContentTypeId'] = asset['assetContents'][0]['genusTypeId']
+
+        req = self.app.post(url,
+                            params=json.dumps(payload),
+                            headers={'content-type': 'application/json'})
+        self.ok(req)
+        item = self.json(req)
+
+        self.assertEqual(
+            item['genusTypeId'],
+            str(QTI_ITEM_ORDER_INTERACTION_OBJECT_MANIPULATION_GENUS)
+        )
+
+        self.assertEqual(
+            item['question']['genusTypeId'],
+            str(QTI_QUESTION_ORDER_INTERACTION_OBJECT_MANIPULATION_GENUS)
+        )
+
+        self.assertEqual(
+            item['answers'][0]['genusTypeId'],
+            str(RIGHT_ANSWER_GENUS)
+        )
+        self.assertEqual(
+            len(item['answers'][0]['choiceIds']),
+            4
+        )
+        self.assertEqual(
+            len(item['question']['choices']),
+            4
+        )
+
+        self.assertNotEqual(
+            item['id'],
+            str(self._item.ident)
+        )
+
+        url = '{0}/{1}/qti'.format(url, unquote(item['id']))
+        req = self.app.get(url)
+        self.ok(req)
+        item_qti = BeautifulSoup(req.body, 'lxml-xml').assessmentItem
+        expected_values = ['id127df214-2a19-44da-894a-853948313dae',
+                           'iddcbf40ab-782e-4d4f-9020-6b8414699a72',
+                           'idb4f6cd03-cf58-4391-9ca2-44b7bded3d4b',
+                           'ide576c9cc-d20e-4ba3-8881-716100b796a0']
+        for index, value in enumerate(item_qti.responseDeclaration.correctResponse.find_all('value')):
+            self.assertEqual(value.string.strip(), expected_values[index])
+
+        item_body = item_qti.itemBody
+
+        order_interaction = item_body.orderInteraction.extract()
+
+        repository_id = str(self._bank.ident).replace('assessment.Bank', 'repository.Repository')
+        audio_asset_label = 'audioTestFile__mp3'
+        image_1_asset_label = 'Picture1_png'
+        image_2_asset_label = 'Picture2_png'
+        image_3_asset_label = 'Picture3_png'
+        image_4_asset_label = 'Picture4_png'
+        audio_asset_id = item['question']['fileIds'][audio_asset_label]['assetId']
+        audio_asset_content_id = item['question']['fileIds'][audio_asset_label]['assetContentId']
+        image_1_asset_id = item['question']['fileIds'][image_1_asset_label]['assetId']
+        image_1_asset_content_id = item['question']['fileIds'][image_1_asset_label]['assetContentId']
+        image_2_asset_id = item['question']['fileIds'][image_2_asset_label]['assetId']
+        image_2_asset_content_id = item['question']['fileIds'][image_2_asset_label]['assetContentId']
+        image_3_asset_id = item['question']['fileIds'][image_3_asset_label]['assetId']
+        image_3_asset_content_id = item['question']['fileIds'][image_3_asset_label]['assetContentId']
+        image_4_asset_id = item['question']['fileIds'][image_4_asset_label]['assetId']
+        image_4_asset_content_id = item['question']['fileIds'][image_4_asset_label]['assetContentId']
+
+        expected_string = """<itemBody>
+<p>
+   Listen to each audio clip and put the pictures of the story in order.
+  </p>
+<p>
+<audio autoplay="autoplay" controls="controls" style="width: 125px">
+<source src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" type="audio/mpeg"/>
+</audio>
+</p>
+
+</itemBody>""".format(repository_id,
+                      audio_asset_id,
+                      audio_asset_content_id)
+
+        self.assertEqual(
+            str(item_body),
+            expected_string
+        )
+
+        self.assertEqual(
+            len(order_interaction.find_all('simpleChoice')),
+            4
+        )
+        self.assertEqual(
+            order_interaction['responseIdentifier'],
+            'RESPONSE_1'
+        )
+        self.assertEqual(
+            order_interaction['shuffle'],
+            'true'
+        )
+
+        expected_choices = {
+            "idb4f6cd03-cf58-4391-9ca2-44b7bded3d4b": """<simpleChoice identifier="idb4f6cd03-cf58-4391-9ca2-44b7bded3d4b">
+<p>
+<img alt="Picture 1" height="100" src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" width="100"/>
+</p>
+</simpleChoice>""".format(repository_id,
+                          image_1_asset_id,
+                          image_1_asset_content_id),
+            "id127df214-2a19-44da-894a-853948313dae": """<simpleChoice identifier="id127df214-2a19-44da-894a-853948313dae">
+<p>
+<img alt="Picture 2" height="100" src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" width="100"/>
+</p>
+</simpleChoice>""".format(repository_id,
+                          image_2_asset_id,
+                          image_2_asset_content_id),
+            "iddcbf40ab-782e-4d4f-9020-6b8414699a72": """<simpleChoice identifier="iddcbf40ab-782e-4d4f-9020-6b8414699a72">
+<p>
+<img alt="Picture 3" height="100" src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" width="100"/>
+</p>
+</simpleChoice>""".format(repository_id,
+                          image_3_asset_id,
+                          image_3_asset_content_id),
+            "ide576c9cc-d20e-4ba3-8881-716100b796a0": """<simpleChoice identifier="ide576c9cc-d20e-4ba3-8881-716100b796a0">
+<p>
+<img alt="Picture 4" height="100" src="http://localhost/api/v1/repository/repositories/{0}/assets/{1}/contents/{2}" width="100"/>
+</p>
+</simpleChoice>""".format(repository_id,
+                          image_4_asset_id,
+                          image_4_asset_content_id)
+        }
+
+        for choice in order_interaction.find_all('simpleChoice'):
+            choice_id = choice['identifier']
+            self.assertEqual(
+                str(choice),
+                expected_choices[choice_id]
+            )
+
     def test_can_create_numeric_response_question_via_rest(self):
         url = '{0}/items'.format(self.url)
 
@@ -11490,6 +12220,161 @@ class QTIEndpointTests(BaseAssessmentTestCase):
    <textEntryInteraction responseIdentifier="RESPONSE"/>
 </p>
 </itemBody>""",
+                "variables": [{
+                    "id": "var1",
+                    "format": "%.4f",
+                    "type": "float",
+                    "min": 1.0,
+                    "max": 10.0,
+                    "step": 0.1
+                }, {
+                    "id": "var2",
+                    "type": "integer",
+                    "min": 1,
+                    "max": 10
+                }],
+                "genusTypeId": str(QTI_QUESTION_NUMERIC_RESPONSE_INTERACTION_GENUS)
+            },
+            "answers": [{
+                "genusTypeId": str(RIGHT_ANSWER_GENUS),
+                "feedback": """<modalFeedback  identifier="Feedback933928139" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+<p></p>
+</modalFeedback>"""
+            },{
+                "genusTypeId": str(WRONG_ANSWER_GENUS),
+                "feedback": """<modalFeedback  identifier="Feedback933928139" outcomeIdentifier="FEEDBACKMODAL" showHide="show">
+<p></p>
+</modalFeedback>"""
+            }]
+        }
+
+        req = self.app.post(url,
+                            params=json.dumps(payload),
+                            headers={'content-type': 'application/json'})
+        self.ok(req)
+        item = self.json(req)
+
+        self.assertEqual(
+            item['genusTypeId'],
+            str(QTI_ITEM_NUMERIC_RESPONSE_INTERACTION_GENUS)
+        )
+
+        self.assertEqual(
+            item['question']['genusTypeId'],
+            str(QTI_QUESTION_NUMERIC_RESPONSE_INTERACTION_GENUS)
+        )
+
+        self.assertIn('var1', item['question']['variables'])
+        self.assertIn('var2', item['question']['variables'])
+
+        self.assertEqual(
+            item['question']['variables']['var1']['min_value'],
+            1.0
+        )
+        self.assertEqual(
+            item['question']['variables']['var1']['max_value'],
+            10.0
+        )
+        self.assertEqual(
+            item['question']['variables']['var1']['type'],
+            'float'
+        )
+        self.assertEqual(
+            item['question']['variables']['var1']['format'],
+            '%.4f'
+        )
+        self.assertEqual(
+            item['question']['variables']['var2']['min_value'],
+            1
+        )
+        self.assertEqual(
+            item['question']['variables']['var2']['max_value'],
+            10
+        )
+        self.assertEqual(
+            item['question']['variables']['var2']['type'],
+            'integer'
+        )
+        self.assertEqual(
+            item['question']['variables']['var2']['step'],
+            1
+        )
+
+        self.assertEqual(
+            item['answers'][0]['genusTypeId'],
+            str(RIGHT_ANSWER_GENUS)
+        )
+        self.assertIn('<p></p>', item['answers'][0]['feedbacks'][0]['text'])
+        self.assertIn('<p></p>', item['answers'][1]['feedbacks'][0]['text'])
+
+        self.assertNotEqual(
+            item['id'],
+            str(self._item.ident)
+        )
+
+        url = '{0}/{1}/qti'.format(url, unquote(item['id']))
+        req = self.app.get(url)
+        self.ok(req)
+        item_qti = BeautifulSoup(req.body, 'lxml-xml').assessmentItem
+        item_body = item_qti.itemBody
+
+        expected_string = """<itemBody>
+<p>
+   Please solve:
+</p>
+<p>
+   <printedVariable format="%.4f" identifier="var1"/>
+   +
+   <printedVariable identifier="var2"/>
+   =
+   <textEntryInteraction responseIdentifier="RESPONSE"/>
+</p>
+</itemBody>"""
+
+        self.assertNotEqual(
+            str(item_body),
+            expected_string
+        )
+
+        # make sure some random numbers are inserted that meet the requirements
+        expression = self._grab_expression(str(item_body))
+        var1 = float(expression[0:expression.index('+')].strip())
+        var2 = int(expression[expression.index('+') + 1::].strip())
+
+        self.assertTrue(1.0 <= var1 <= 10.0)
+        self.assertTrue(1 <= var2 <= 10)
+
+        # make sure the questionId is "magical"
+        self.assertNotEqual(
+            item['id'],
+            item['question']['id']
+        )
+        self.assertNotIn('?', item['question']['id'])
+        self.assertEqual(
+            item['question']['id'].split('%40')[-1],
+            'qti-numeric-response'
+        )
+        self.assertIn('var1', item['question']['id'].split('%3A')[-1].split('%40')[0])
+        self.assertIn('var2', item['question']['id'].split('%3A')[-1].split('%40')[0])
+
+    def test_item_body_provided_numeric_response(self):
+        url = '{0}/items'.format(self.url)
+
+        payload = {
+            "genusTypeId": str(QTI_ITEM_NUMERIC_RESPONSE_INTERACTION_GENUS),
+            "name": "Question 1",
+            "description": "For testing",
+            "question": {
+                "questionString": """<p>
+   Please solve:
+</p>
+<p>
+   <printedVariable identifier="var1"/>
+   +
+   <printedVariable identifier="var2"/>
+   =
+   <textEntryInteraction responseIdentifier="RESPONSE"/>
+</p>""",
                 "variables": [{
                     "id": "var1",
                     "format": "%.4f",


### PR DESCRIPTION
This is kind of a + feature to PR #7 (so client-side doesn't necessarily have to add in QTI XML tags, and this makes the data more generic on the server-side).