### PR TITLE
bump to dlkit 0.5.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.4.1
 cffi==1.7.0
 cryptography==1.4
-dlkit==0.5.13
+dlkit==0.5.17
 enum34==1.1.6
 html5lib==0.9999999
 idna==2.1


### PR DESCRIPTION
Adds config setting for caching URI, `cachingHostURI`, in the `MONGO` section of `configs.py`.