### PR TITLE
update dlkit to 0.7.0; add feature flag to config

### DIFF
--- a/dlkit_configs/configs.py
+++ b/dlkit_configs/configs.py
@@ -299,6 +299,14 @@ JSON_1 = {
                 {'value': True, 'priority': 1}
             ]
         },
+        'bypassAuthorizationForFilesRecordAssetContentLookup': {
+            'syntax': 'BOOLEAN',
+            'displayName': 'Use direct AssetContentLookup for FilesRecord map',
+            'description': 'Bypasses any catalog-hierarchy based authorization for (Asset) AssetContent lookup',
+            'values': [
+                {'value': False, 'priority': 1}
+            ]
+        },
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.4.1
 cffi==1.7.0
 cryptography==1.4
 diskcache==3.0.1
-dlkit==0.6.9
+dlkit==0.7.0
 enum34==1.1.6
 html5lib==0.9999999
 idna==2.1


### PR DESCRIPTION
Fixes issue with OEA authoring / client when an image asset in a question might be from a bank "above" the current one, in the hierarchy. Adds a new configuration parameter to the `JSON` config in `dlkit_configs/config.py`:

```
        'bypassAuthorizationForFilesRecordAssetContentLookup': {
            'syntax': 'BOOLEAN',
            'displayName': 'Use direct AssetContentLookup for FilesRecord map',
            'description': 'Bypasses any catalog-hierarchy based authorization for (Asset) AssetContent lookup',
            'values': [
                {'value': False, 'priority': 1}
            ]
        },
```

To use the deprecated / old / bad behavior that the OEA authoring tool allows, make sure to set the above configuration behavior to `True`. This is compatible with `dlkit` `0.7.0`+.